### PR TITLE
ci: add anti-slop PR quality workflow

### DIFF
--- a/.github/workflows/pr-quality.yaml
+++ b/.github/workflows/pr-quality.yaml
@@ -1,0 +1,18 @@
+name: PR Quality
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  anti-slop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peakoss/anti-slop@v0
+        with:
+          max-failures: 4


### PR DESCRIPTION
Add anti-slop workflow to detect low-quality/AI-generated PRs automatically.

This adds a GitHub Actions workflow that runs on PR open/reopen and uses the anti-slop action to detect and automatically close low-quality PRs.

Default configuration:
- max-failures: 4 (balanced approach)
- Blocks PRs from main/master branches
- Limits PR size (50 files, 10000 lines)
- Requires description, limits emojis/code references
- Detects spam usernames, requires 30-day account age
- Exempts owners/members/collaborators and known bots
- Closes PR when threshold exceeded

Closes: adds PR quality gate for the project.